### PR TITLE
Added custom json deserializer for Content 'data'

### DIFF
--- a/sdk/src/main/java/com/adzerk/android/sdk/rest/ContentData.java
+++ b/sdk/src/main/java/com/adzerk/android/sdk/rest/ContentData.java
@@ -1,0 +1,132 @@
+package com.adzerk.android.sdk.rest;
+
+import com.google.gson.JsonObject;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Contains the data and metadata parsed from a Content element. Not intended for API consumers.
+ * @see Content
+ */
+public class ContentData {
+
+    // data key for the json metadata
+    static String KEY_CUSTOM_DATA = "customData";
+
+    // data key for image url
+    static String KEY_IMAGE_URL = "imageUrl";
+
+    // data key for title
+    static String KEY_TITLE = "title";
+
+    // map of creative data (title, height, width, etc) used to build the content body
+    Map<String, Object> creativeData;
+
+    // map of creative metadata; the deserialized JSON metadata from the creative
+    Map<String, Object> creativeMetadata;
+
+    // raw creative metadata JSON object; useful for clients needing custom deserialization
+    JsonObject creativeMetadataJson;
+
+
+    public ContentData(Map<String, Object> creativeData, JsonObject creativeMetadataJson) {
+        this.creativeData = creativeData;
+        this.creativeMetadataJson = creativeMetadataJson;
+    }
+
+    /**
+     * Returns TRUE if content contains creativeData
+     * @return true if creativeData is not empty
+     */
+    boolean hasCreativeData() {
+        return creativeData != null && !creativeData.isEmpty();
+    }
+
+    /**
+     * Returns creativeData object that has fields used to build the content
+     * @return map of key-value pairs
+     */
+    Map<String, Object> getCreativeData() {
+        return creativeData;
+    }
+
+    /**
+     * Returns creativeData object that has fields used to build the content
+     * @return map of key-value pairs
+     */
+    Object getCreativeData(String key) {
+        if (hasCreativeData() && creativeData.containsKey(key)) {
+            return creativeData.get(key);
+        }
+        return null;
+    }
+
+    /**
+     * Creatives may specify optional metadata in JSON format. This method returns that JSON metadata deserialized
+     * as Java Obects.
+     * <p>
+     * If the creative data contains JSON metadata, it may be used by itself or together the content 'body'
+     * to render the ad.
+     * @return JSON metadata content
+     */
+    Map<String, Object> getCreativeMetadata() {
+
+        if (hasCreativeData() && creativeData.containsKey(KEY_CUSTOM_DATA)) {
+            Object creativeMetadata = creativeData.get(KEY_CUSTOM_DATA);
+            if (creativeMetadata instanceof Map) {
+                return (Map) creativeMetadata;
+            }
+        }
+        return Collections.EMPTY_MAP;
+    }
+
+    /**
+     * Returns a value from the JSON metadata content set by the creative.
+     * @param key   JSON attribute name
+     * @return  object value or null
+     */
+    Object getCreativeMetadata(String key) {
+        Map<String, Object> creativeMetadata = getCreativeMetadata();
+        if (!creativeMetadata.isEmpty() && creativeMetadata.containsKey(key)) {
+            return creativeMetadata.get(key);
+        }
+        return null;
+    }
+
+    /**
+     * Returns the creative metadata as a JsonObject.
+     * @return json object containing metadata for the creative or null
+     */
+    JsonObject getCreativeMetadataAsJson() {
+        return creativeMetadataJson;
+    }
+
+    /**
+     * Convenience method that returns the creative metadata as a String of JSON.
+     * @return json string or null
+     */
+    String getCreativeMetadataAsString() {
+        if (creativeMetadataJson != null) {
+            return creativeMetadataJson.toString();
+        }
+        return null;
+    }
+
+    /**
+     * Returns the value of the 'imageUrl' from creativeData
+     * @return url of image or null
+     */
+    String getImageUrl() {
+        return (getCreativeData(KEY_IMAGE_URL) != null) ? creativeData.get(KEY_IMAGE_URL).toString() : null;
+    }
+
+    /**
+     * Returns the value of the 'title' from creativeData
+     * @return ad title or null
+     */
+    String getTitle() {
+        return (getCreativeData(KEY_TITLE) != null) ? creativeData.get(KEY_TITLE).toString() : null;
+    }
+
+}

--- a/sdk/src/test/java/com/adzerk/android/sdk/rest/ContentTest.java
+++ b/sdk/src/test/java/com/adzerk/android/sdk/rest/ContentTest.java
@@ -4,6 +4,9 @@ import com.adzerk.android.sdk.AdzerkSdk;
 import com.adzerk.android.sdk.AdzerkSdk.ResponseListener;
 import com.adzerk.android.sdk.BuildConfig;
 import com.adzerk.android.sdk.MockClient;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -14,7 +17,6 @@ import org.robolectric.annotation.Config;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import retrofit.RetrofitError;
 
@@ -61,6 +63,14 @@ public class ContentTest {
                 assertThat(div1Content.getCreativeMetadata("foo")).isEqualTo(new Double(42));
                 assertThat(div1Content.getCreativeMetadata("bar")).isEqualTo("some string");
 
+                // verify customData JsonObject & raw JSON String:
+                Gson gson = new GsonBuilder().create();
+                JsonObject expectedJsonObject = gson.fromJson(customData, JsonObject.class);
+                assertThat(div1Content.getCreativeMetadataAsJson()).isNotNull();
+                assertThat(div1Content.getCreativeMetadataAsJson()).isEqualToComparingFieldByField(expectedJsonObject);
+                assertThat(div1Content.getCreativeMetadataAsString().replaceAll("\\s+", ""))
+                      .isEqualToIgnoringCase(customData.replaceAll("\\s+", ""));
+
                 latch.countDown();
             }
 
@@ -73,7 +83,8 @@ public class ContentTest {
 
 
         try {
-            latch.await(3000, TimeUnit.MILLISECONDS);
+            latch.await();
+            //latch.await(3000, TimeUnit.MILLISECONDS);
             if (errors[0] != null) {
                 fail(errors[0]);
             }
@@ -95,6 +106,7 @@ public class ContentTest {
         return new Request.Builder(placements).build();
     }
 
+    private static String customData = "{ \"foo\": 42, \"bar\": \"some string\" }";
     
     private String getMockJsonResponse() {
         


### PR DESCRIPTION
- ContentData holds map for creative data and creative metadata
- Content delegates calls that access creative data and creative metadata to ContentData
- ContentData is intended for internal use only
  - would be better if this class was private; it is needed when registering the jsonserializer with GSON
