### PR TITLE
Include support-annotations dep for javadocs

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -89,11 +89,17 @@ install {
     }
 }
 
+configurations {
+  javadocDeps
+}
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:support-annotations:22.2.0'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
+
+    javadocDeps 'com.android.support:support-annotations:22.2.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.+'


### PR DESCRIPTION
4 tests were failing for me because Robolectric could not find AndroidManifest.xml. I noticed when re-building the project that the javadocs dependency was failing to compile because it was missing support-annotations. (I assume this has something to do with the test runner not finding AndroidManifest.xml, perhaps there was some annotation telling it where to find it.)

After some googling I found this:
http://stackoverflow.com/questions/29663918/android-gradle-javadoc-annotation-does-not-exists

Adding `com.android.support:support-annotations:22.2.0` to the javadoc deps fixed the problem for me -- I was then able to run the tests successfully.

@fmedlin @bdiegel I'm new to Java and Android development... am I on the right track here? Do you think this PR would break anything for other users?