### PR TITLE
Rename Event fields to match API responses.

### DIFF
--- a/sdk/src/main/java/com/adzerk/android/sdk/rest/Event.java
+++ b/sdk/src/main/java/com/adzerk/android/sdk/rest/Event.java
@@ -60,25 +60,25 @@ public class Event {
 
 
     // event identifier
-    int eventId;
+    int id;
 
     // url to call to track an event
-    String eventUrl;
+    String url;
 
     /**
      * Returns an event identifier
      * @return numeric event id
      */
-    public int getEventId() {
-        return eventId;
+    public int getId() {
+        return id;
     }
 
     /**
      * Returns tracking URL of custom event
      * @return tracking url
      */
-    public String getEventUrl() {
-        return eventUrl;
+    public String getUrl() {
+        return url;
     }
 
 }

--- a/sdk/src/test/java/com/adzerk/android/sdk/rest/DecisionResponseTest.java
+++ b/sdk/src/test/java/com/adzerk/android/sdk/rest/DecisionResponseTest.java
@@ -51,8 +51,8 @@ public class DecisionResponseTest {
                 .isNotEmpty()
                 .hasSize(3);
 
-        assertThat(div1.getEvents().get(0).getEventId()).isEqualTo(12);
-        assertThat(div1.getEvents().get(0).getEventUrl()).contains("adzerk");
+        assertThat(div1.getEvents().get(0).getId()).isEqualTo(12);
+        assertThat(div1.getEvents().get(0).getUrl()).contains("adzerk");
     }
 
     @Test
@@ -100,14 +100,14 @@ public class DecisionResponseTest {
         "      ]," +
         "       \"impressionUrl\": \"http://engine.adzerk.net/impression\", " +
         "       \"events\": [" +
-        "        { eventId: 12," +
-        "          eventUrl: \"http://engine.adzerk.net/e.gif?...\"" +
+        "        { id: 12," +
+        "          url: \"http://engine.adzerk.net/e.gif?...\"" +
         "        }," +
-        "        { eventId: 13," +
-        "          eventUrl: \"http://engine.adzerk.net/e.gif?...\"" +
+        "        { id: 13," +
+        "          url: \"http://engine.adzerk.net/e.gif?...\"" +
         "        }," +
-        "        { eventId: 14," +
-        "          eventUrl: \"http://engine.adzerk.net/e.gif?...\"" +
+        "        { id: 14," +
+        "          url: \"http://engine.adzerk.net/e.gif?...\"" +
         "        }" +
         "       ]" +
         "    }," +


### PR DESCRIPTION
According to API spec there should be eventId and eventUrl fields but
instead of that the API is actually returning id and url fields.

See issue #51 