### PR TITLE
Use Adzerk e-dash domains

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -110,6 +110,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.8.47'
     testImplementation 'org.robolectric:robolectric:3.3.1'
     testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.9'
 }
 
 task sourcesJar(type: Jar) {

--- a/sdk/src/main/java/com/adzerk/android/sdk/AdzerkSdk.java
+++ b/sdk/src/main/java/com/adzerk/android/sdk/AdzerkSdk.java
@@ -1,5 +1,6 @@
 package com.adzerk.android.sdk;
 
+import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
@@ -44,8 +45,8 @@ import retrofit2.converter.gson.GsonConverterFactory;
  * <p>
  * <pre>
  * {@code
- * // Get instance of the SDK
- * AdzerkSdk sdk = AdzerkSdk.getInstance();
+ * // Create instance of the SDK
+ * AdzerkSdk sdk = new AdzerkSdk.Builder().networkId(23L).build();
  *
  * // Build the Request
  * Request request = new Request.Builder()
@@ -60,9 +61,9 @@ import retrofit2.converter.gson.GsonConverterFactory;
  */
 public class AdzerkSdk {
     static final String TAG = AdzerkSdk.class.getSimpleName();
-    static final String ADZERK_ENDPOINT = "https://engine.adzerk.net";
 
-    static AdzerkSdk instance;
+    long defaultNetworkId;
+    String baseUrl;
 
     AdzerkService service;
     OkHttpClient client;
@@ -93,8 +94,8 @@ public class AdzerkSdk {
     }
 
     private interface AdzerkCallbackListener<T> {
-        public void success(T response);
-        public void error(AdzerkError error);
+        void success(T response);
+        void error(AdzerkError error);
     }
 
     /**
@@ -109,18 +110,48 @@ public class AdzerkSdk {
     public interface UserListener extends AdzerkCallbackListener<User> {
     }
 
+    public static class Builder {
 
-    /**
-     * Returns the SDK instance for making Adzerk API calls.
-     *
-     * @return sdk instance
-     */
-    public static AdzerkSdk getInstance() {
-        if (instance == null) {
-            instance = new AdzerkSdk();
+        static final String E_DASH_HOSTNAME_FORMAT = "e-%d.adzerk.net";
+        static final String BASE_URL_FORMAT = "%s://%s";
+
+        private long networkId;
+        private String hostname;
+        private String protocol = "https";
+
+        public Builder() {
         }
 
-        return instance;
+        public Builder networkId(long networkId) {
+            this.networkId = networkId;
+            return this;
+        }
+
+        public Builder hostname(String hostname) {
+            this.hostname = hostname;
+            return this;
+        }
+
+        public Builder protocol(String protocol) {
+            this.protocol = protocol;
+            return this;
+        }
+
+        public AdzerkSdk build() {
+            if (this.networkId == 0L) {
+                throw new IllegalStateException("A networkId is required");
+            }
+            String baseUrl = createBaseUrl();
+            return new AdzerkSdk(baseUrl, this.networkId);
+        }
+
+        private String createBaseUrl() {
+            if (!TextUtils.isEmpty(this.hostname)) {
+                return String.format(BASE_URL_FORMAT, this.protocol, this.hostname);
+            }
+
+            return String.format(BASE_URL_FORMAT, this.protocol, String.format(E_DASH_HOSTNAME_FORMAT, this.networkId));
+        }
     }
 
     /**
@@ -143,11 +174,16 @@ public class AdzerkSdk {
         return new AdzerkSdk(null, client);
     }
 
-    private AdzerkSdk() {
+    private AdzerkSdk(String baseUrl, long networkId) {
+        this.baseUrl = baseUrl;
+        this.defaultNetworkId = networkId;
         service = getAdzerkService();
     }
 
+    // Internal use - support for unit tests
     private AdzerkSdk(AdzerkService service, OkHttpClient client) {
+        this.baseUrl = "https://engine.adzerk.net";
+        this.defaultNetworkId = 9792L;
         this.service = service;
         this.client = client;
     }
@@ -373,7 +409,7 @@ public class AdzerkSdk {
                   .create();
 
             Retrofit.Builder builder = new Retrofit.Builder()
-                  .baseUrl(ADZERK_ENDPOINT)
+                  .baseUrl(baseUrl)
                   .addConverterFactory(GsonConverterFactory.create(gson));
 
             // test client

--- a/sdk/src/main/java/com/adzerk/android/sdk/AdzerkSdk.java
+++ b/sdk/src/main/java/com/adzerk/android/sdk/AdzerkSdk.java
@@ -196,6 +196,11 @@ public class AdzerkSdk {
      * @param listener Can be null, but caller will never get notifications.
      */
     public void requestPlacement(Request request, @Nullable final DecisionListener listener) {
+        request.getPlacements().forEach( p -> {
+            if (p.getNetworkId() == 0L) {
+                p.setNetworkId(this.defaultNetworkId);
+            }
+        });
         Call<DecisionResponse> call = getAdzerkService().request(request);
         call.enqueue(new AdzerkCallback<DecisionResponse, DecisionResponse>("RequestPlacement", listener));
     }
@@ -206,6 +211,11 @@ public class AdzerkSdk {
      * @param request Request specifying one or more Placements
      */
     public DecisionResponse requestPlacementSynchronous(Request request) {
+        request.getPlacements().forEach( p -> {
+            if (p.getNetworkId() == 0L) {
+                p.setNetworkId(this.defaultNetworkId);
+            }
+        });
         Call<DecisionResponse> call = getAdzerkService().request(request);
 
         try {

--- a/sdk/src/main/java/com/adzerk/android/sdk/rest/Placement.java
+++ b/sdk/src/main/java/com/adzerk/android/sdk/rest/Placement.java
@@ -64,10 +64,40 @@ public class Placement {
     /**
      * Creates a Placement with all required fields. A Placement identifies a place where an ad can be served
      * and has a unique divName. To request multiple ads using a single Request you specify multiple Placements.
+     * The SDK will provide the default networkId.
      *
      * <pre>
      * {@code
      * // create placement with required arguments
+     * Placement div1 = new Placement("div1", 1L, 5);
+     * }
+     * </pre>
+     *
+     * The Response to an ad Request returns a corresponding Decision for each Placement. The Decision contains the
+     * ad that was selected for a given Placement. The DecisionResponse relates a Decision to Placement by divName.
+     *
+     * @param divName       unique name for the placement
+     * @param siteId        site id to use when selecting an ad
+     * @param adTypes       one or more integer ad types to use when selecting an ad
+     */
+    public Placement(@NonNull String divName, long siteId, int... adTypes) {
+        setDivName(divName);
+        setSiteId(siteId);
+
+        if (adTypes == null || adTypes.length < 1) {
+            throw new IllegalArgumentException("At least one ad type must be specified");
+        }
+
+        addAdTypes(adTypes);
+    }
+
+    /**
+     * Creates a Placement and for specified networkId. A Placement identifies a place where an ad can be served
+     * and has a unique divName. To request multiple ads using a single Request you specify multiple Placements.
+     *
+     * <pre>
+     * {@code
+     * // create placement for networkId with required arguments
      * Placement div1 = new Placement("div1", 1L, 2L, 5);
      * }
      * </pre>

--- a/sdk/src/test/java/com/adzerk/android/sdk/rest/PlacementTest.java
+++ b/sdk/src/test/java/com/adzerk/android/sdk/rest/PlacementTest.java
@@ -29,7 +29,7 @@ public class PlacementTest {
     @Test
     public void itShouldThrowOnNoAdType() {
         try {
-            Placement div1 = new Placement("div1", 9999, 77777);
+            Placement div1 = new Placement("div1", 9999L, 77777L);
         } catch (IllegalArgumentException e) {
             // success
         }
@@ -38,7 +38,7 @@ public class PlacementTest {
     @Test
     public void itShouldThrowOnNullDivName() {
         try {
-            Placement div1 = new Placement(null, 9999, 77777, 5);
+            Placement div1 = new Placement(null, 9999L, 77777L, 5);
         } catch (IllegalArgumentException e) {
             // success
         }
@@ -78,7 +78,7 @@ public class PlacementTest {
             final Set<Integer> eventIds = new HashSet(Arrays.asList(1, 2, 3));
 
             // create placement & set optional attributes
-            Placement div1 = new Placement("div1", 9999, 77777, 5, 6)
+            Placement div1 = new Placement("div1", 9999L, 77777L, 5, 6)
                 .setZoneIds(zoneIds)
                 .setCampaignId(campaignId)
                 .setFlightId(flightId)
@@ -103,7 +103,7 @@ public class PlacementTest {
     public void itShouldAddOptionalAttributes() {
         try {
             // create placement and add optional zone and event ids
-            Placement div1 = new Placement("div1", 9999, 77777, 5, 6)
+            Placement div1 = new Placement("div1", 9999L, 77777L, 5, 6)
                   .addZoneIds(10, 11, 11, 12)
                   .addEventIds(1, 1, 2);
 
@@ -121,7 +121,7 @@ public class PlacementTest {
     @Test
     public void itShouldSetProperties() {
         // create placement and add properties
-        Placement div1 = new Placement("div1", 123, 456, 4, 5)
+        Placement div1 = new Placement("div1", 123L, 456L, 4, 5)
             .addProperty("foo", 42)
             .addProperty("bar", "example")
             .addProperty("baz", Arrays.asList("one", "two"));
@@ -136,7 +136,7 @@ public class PlacementTest {
     public void itShouldSerializePlacements() {
 
         // create placements will all attributes
-        Placement div1 = new Placement("div1", 123, 456, 4, 5)
+        Placement div1 = new Placement("div1", 123L, 456L, 4, 5)
             .addZoneIds(789)
             .setCampaignId(123)
             .setFlightId(456)


### PR DESCRIPTION
Support for e-dash domains, top-level networkId, and custom hostname. Add unit tests.

Create SDK with top-level networkId:
```
AdzerkSdk sdk = new AdzerkSdk.Builder().networkId(23L).build();
```

Optional custom hostname:
```
AdzerkSdk sdk = new AdzerkSdk.Builder().networkId(23L).hostname("custom.acme.com").build();
```


BREAKING CHANGE: uses builder pattern to create sdk (singleton removed)

fixes #68 