### PR TITLE
breaking: add support for multi-winners

### DIFF
--- a/sdk/src/main/java/com/adzerk/android/sdk/AdzerkSdk.java
+++ b/sdk/src/main/java/com/adzerk/android/sdk/AdzerkSdk.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import com.adzerk.android.sdk.rest.AdzerkService;
 import com.adzerk.android.sdk.rest.ContentData;
 import com.adzerk.android.sdk.rest.DecisionResponse;
+import com.adzerk.android.sdk.rest.Placement;
 import com.adzerk.android.sdk.rest.Request;
 import com.adzerk.android.sdk.rest.User;
 import com.adzerk.android.sdk.rest.UserProperties;
@@ -196,11 +197,11 @@ public class AdzerkSdk {
      * @param listener Can be null, but caller will never get notifications.
      */
     public void requestPlacement(Request request, @Nullable final DecisionListener listener) {
-        request.getPlacements().forEach( p -> {
+        for (Placement p : request.getPlacements()) {
             if (p.getNetworkId() == 0L) {
                 p.setNetworkId(this.defaultNetworkId);
             }
-        });
+        }
         Call<DecisionResponse> call = getAdzerkService().request(request);
         call.enqueue(new AdzerkCallback<DecisionResponse, DecisionResponse>("RequestPlacement", listener));
     }
@@ -211,11 +212,11 @@ public class AdzerkSdk {
      * @param request Request specifying one or more Placements
      */
     public DecisionResponse requestPlacementSynchronous(Request request) {
-        request.getPlacements().forEach( p -> {
+        for (Placement p : request.getPlacements()) {
             if (p.getNetworkId() == 0L) {
                 p.setNetworkId(this.defaultNetworkId);
             }
-        });
+        }
         Call<DecisionResponse> call = getAdzerkService().request(request);
 
         try {

--- a/sdk/src/main/java/com/adzerk/android/sdk/gson/DecisionsDeserializer.java
+++ b/sdk/src/main/java/com/adzerk/android/sdk/gson/DecisionsDeserializer.java
@@ -1,0 +1,64 @@
+package com.adzerk.android.sdk.gson;
+
+import com.adzerk.android.sdk.rest.Decision;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class DecisionsDeserializer implements JsonDeserializer<Map<String, List<Decision>>> {
+
+    @Override
+    public Map<String, List<Decision>> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        Map<String, List<Decision>> decisions = new HashMap<>();
+
+        JsonObject winnersObject = json.getAsJsonObject();
+        Set<String> placementNames = winnersObject.keySet();
+        String firstPlacement = placementNames.iterator().next();
+
+        if (winnersObject.get(firstPlacement) instanceof JsonArray) {
+            // multi-winners response
+            for (String placementName : placementNames) {
+                List<Decision> decisionList = new ArrayList<>();
+                JsonArray multiWinners = winnersObject.getAsJsonArray(placementName);
+
+                for (JsonElement nextWinner : multiWinners) {
+                    if (nextWinner instanceof JsonObject) {
+                        JsonObject decisionObject = nextWinner.getAsJsonObject();
+                        Decision decision = context.deserialize(decisionObject, Decision.class);
+                        decisionList.add(decision);
+                    }
+                }
+                decisions.put(placementName, decisionList);
+            }
+        } else {
+            // single winner response
+            for (String placementName : placementNames) {
+                JsonElement member = winnersObject.get(placementName);
+                if (member instanceof JsonObject) {
+                    JsonObject decisionObject = winnersObject.getAsJsonObject(placementName);
+                    Decision decision = context.deserialize(decisionObject, Decision.class);
+                    List<Decision> decisionList = new ArrayList<>();
+                    decisionList.add(decision);
+                    decisions.put(placementName, decisionList);
+                } else if (member instanceof JsonNull) {
+                    decisions.put(placementName, null);
+                } else {
+                    throw new JsonParseException("Expected Object or null");
+                }
+            }
+        }
+
+        return decisions;
+    }
+}

--- a/sdk/src/main/java/com/adzerk/android/sdk/rest/DecisionResponse.java
+++ b/sdk/src/main/java/com/adzerk/android/sdk/rest/DecisionResponse.java
@@ -1,20 +1,25 @@
 package com.adzerk.android.sdk.rest;
 
+import com.adzerk.android.sdk.gson.DecisionsDeserializer;
+import com.google.gson.annotations.JsonAdapter;
+
+import java.util.List;
 import java.util.Map;
 
 /**
  * The DecisionResponse to an ad {@link Request}.
  * <p>
- * A DecisionResponse will contain zero or more {@link Decision}s, one per {@link Placement} that was sent in on the requestPlacement.
- * If no ad was selected for a given Placement, the corresponding Decision entry will be undefined (null).
+ * A DecisionResponse will contain zero or more {@link Decision}s per {@link Placement} that was sent in on the requestPlacement.
+ * If no ad was selected for a given Placement, the corresponding entry will be undefined (null).
  */
 public class DecisionResponse {
 
     // identifies the unique user that places the requestPlacement
     User user;
 
-    // each Decision represents the ad that was selected to be served for a given Placement
-    Map<String, Decision> decisions;
+    // each Decision represents an ad that was selected to be served for a given Placement
+    @JsonAdapter(DecisionsDeserializer.class)
+    Map<String, List<Decision>> decisions;
 
     /**
      * Returns the User key which uniquely identifies the user that places the requestPlacement
@@ -25,18 +30,18 @@ public class DecisionResponse {
     }
 
     /**
-     * Returns mapping from {@link Placement} name to the {@link Decision} that represents the ad selected to be served
-     * @return map of decisions by placement name
+     * Returns mapping from {@link Placement} name to the list of {@link Decision}s that represents the ad selected to be served
+     * @return map of selected decisions by placement name
      */
-    public Map<String, Decision> getDecisions() {
+    public Map<String, List<Decision>> getDecisions() {
         return decisions;
     }
 
     /**
-     * Returns the {@link Decision} by name
-     * @return decison for specified placement name
+     * Returns the list of {@link Decision}s by Placement name
+     * @return one or more decisions for specified placement name
      */
-    public Decision getDecision(String name) {
+    public List<Decision> getDecisions(String name) {
         return decisions.get(name);
     }
 

--- a/sdk/src/main/java/com/adzerk/android/sdk/rest/Placement.java
+++ b/sdk/src/main/java/com/adzerk/android/sdk/rest/Placement.java
@@ -60,6 +60,9 @@ public class Placement {
     // array of numeric event types. Requests tracking URLs for custom events
     Set<Integer> eventIds;
 
+    // maximum number of winners (selections) that can be included in the placement
+    Integer count;
+
 
     /**
      * Creates a Placement with all required fields. A Placement identifies a place where an ad can be served
@@ -385,5 +388,24 @@ public class Placement {
             this.eventIds.add(eventId);
         }
         return this;
+    }
+
+    /**
+     * Returns the maximum number of winners requested per Placement
+     *
+     *  @return number of ads requested
+     */
+    public int getCount() {
+        return count;
+    }
+
+    /**
+     * Maximum number of winners (selections) that can be included in the Placement
+     *
+     * @param count number of ads to return (between 1 and 20)
+     **/
+    public Placement setCount(int count) {
+        this.count = count;
+        return  this;
     }
 }

--- a/sdk/src/test/java/com/adzerk/android/sdk/rest/ContentTest.java
+++ b/sdk/src/test/java/com/adzerk/android/sdk/rest/ContentTest.java
@@ -34,7 +34,7 @@ public class ContentTest {
         assertThat(response).isNotNull();
 
         // Content
-        Decision div1 = response.getDecision("div1");
+        Decision div1 = response.getDecisions("div1").get(0);
         List<Content> contents = div1.getContents();
         assertThat(contents.size()).isEqualTo(1);
         Content div1Content = contents.get(0);

--- a/sdk/src/test/java/com/adzerk/android/sdk/rest/DecisionResponseTest.java
+++ b/sdk/src/test/java/com/adzerk/android/sdk/rest/DecisionResponseTest.java
@@ -10,6 +10,8 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.List;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
@@ -36,9 +38,9 @@ public class DecisionResponseTest {
         // Decisions
         assertThat(response.getDecisions()).containsKey("div1");
         assertThat(response.getDecisions()).containsKey("div2");
-        assertThat(response.getDecision("div2")).isNull();
+        assertThat(response.getDecisions("div2")).isNull();
 
-        Decision div1 = response.getDecision("div1");
+        Decision div1 = response.getDecisions("div1").get(0);
         assertThat(div1.getAdId()).isEqualTo(111);
         assertThat(div1.getCreativeId()).isEqualTo(222);
         assertThat(div1.getFlightId()).isEqualTo(333);
@@ -60,11 +62,28 @@ public class DecisionResponseTest {
         DecisionResponse response = sdk.requestPlacementSynchronous(createTestRequest());
         assertThat(response).isNotNull();
 
-        Content content = response.getDecision("div1").getContents().get(0);
+        Content content = response.getDecisions("div1").get(0).getContents().get(0);
         assertThat(content).isNotNull();
         assertThat(content.hasCreativeData()).isTrue();
         assertThat(content.isImage()).isTrue();
         assertThat(content.getImageUrl()).isEqualTo("http://static.adzerk.net/cat-eating-spaghetti.jpg");
+    }
+
+    @Test
+    public void itShouldDeserializeMultiWinners() {
+        AdzerkSdk sdk = AdzerkSdk.createInstance(new MockClient(JSON_MULTI_WINNERS).buildClient());
+
+        DecisionResponse response = sdk.requestPlacementSynchronous(createTestRequest());
+        assertThat(response).isNotNull();
+
+        // User
+        assertThat(response.getUser().getKey()).isEqualTo("ue1-a58d96713f6a41edb42695d24178e224");
+
+        // Decisions
+        assertThat(response.getDecisions()).containsKey("div1");
+
+        List<Decision> div1Decisions = response.getDecisions("div1");
+        assertThat(div1Decisions).isNotNull().isNotEmpty().hasSize(3);
     }
 
     private Request createTestRequest() {
@@ -115,4 +134,88 @@ public class DecisionResponseTest {
         "  }" +
         "}";
 
+    static final String JSON_MULTI_WINNERS = "{" +
+            "  \"user\": {" +
+            "    \"key\": \"ue1-a58d96713f6a41edb42695d24178e224\"" +
+            "  }," +
+            "  \"decisions\": {" +
+            "    \"div1\": [" +
+            "      {" +
+            "        \"adId\": 20857910," +
+            "        \"creativeId\": 18209784," +
+            "        \"flightId\": 12637354," +
+            "        \"campaignId\": 1772372," +
+            "        \"priorityId\": 208307," +
+            "        \"clickUrl\": \"https://e-9792.adzerk.net/r?e=eyJ2IjoiMS42IiwiYXYiOjkwNDA1MCwiYXQiOjE2MywiYnQiOjAsImNtIjoxNzcyMzcyLCJjaCI6NTE1MDksImNrIjp7fSwiY3IiOjE4MjA5Nzg0LCJkaSI6IjMwZTZhYjRmY2U4NzRkNzJiNWJjMjdhNjZhMDRhYWM2IiwiZGoiOjAsImlpIjoiZjMzY2Q3Y2RmMmY4NDk1MGFiZDM3ODg0NGY3Y2M3YzUiLCJkbSI6MywiZmMiOjIwODU3OTEwLCJmbCI6MTI2MzczNTQsImlwIjoiMTM2LjU2LjI5LjY0IiwibnciOjk3OTIsInBjIjowLCJlYyI6MCwiZXAiOm51bGwsInByIjoyMDgzMDcsInJ0IjowLCJycyI6NTAwLCJzYSI6IjgiLCJzYiI6ImktMDk4YzBmNmY4MDg5ZjY0OTUiLCJzcCI6Mjc1NzIsInN0IjoxMTMzODk4LCJ1ayI6InVlMS1hNThkOTY3MTNmNmE0MWVkYjQyNjk1ZDI0MTc4ZTIyNCIsInRzIjoxNjAzNTc5NjI4ODMzLCJwbiI6ImRpdjEiLCJnYyI6dHJ1ZSwiZ0MiOnRydWUsImdzIjoibm9uZSIsInR6IjoiVVRDIiwidXIiOiJodHRwczovL3d3dy5hZHplcmsuY29tIn0&s=b_aCdGnYWZtVF-nn761OKIlO4Ts\"," +
+            "        \"impressionUrl\": \"https://e-9792.adzerk.net/i.gif?e=eyJ2IjoiMS42IiwiYXYiOjkwNDA1MCwiYXQiOjE2MywiYnQiOjAsImNtIjoxNzcyMzcyLCJjaCI6NTE1MDksImNrIjp7fSwiY3IiOjE4MjA5Nzg0LCJkaSI6IjMwZTZhYjRmY2U4NzRkNzJiNWJjMjdhNjZhMDRhYWM2IiwiZGoiOjAsImlpIjoiZjMzY2Q3Y2RmMmY4NDk1MGFiZDM3ODg0NGY3Y2M3YzUiLCJkbSI6MywiZmMiOjIwODU3OTEwLCJmbCI6MTI2MzczNTQsImlwIjoiMTM2LjU2LjI5LjY0IiwibnciOjk3OTIsInBjIjowLCJlYyI6MCwiZXAiOm51bGwsInByIjoyMDgzMDcsInJ0IjowLCJycyI6NTAwLCJzYSI6IjgiLCJzYiI6ImktMDk4YzBmNmY4MDg5ZjY0OTUiLCJzcCI6Mjc1NzIsInN0IjoxMTMzODk4LCJ1ayI6InVlMS1hNThkOTY3MTNmNmE0MWVkYjQyNjk1ZDI0MTc4ZTIyNCIsInRzIjoxNjAzNTc5NjI4ODM0LCJwbiI6ImRpdjEiLCJnYyI6dHJ1ZSwiZ0MiOnRydWUsImdzIjoibm9uZSIsInR6IjoiVVRDIiwiYmEiOjEsImZxIjowfQ&s=vPH8ubKqTKtyICkRmTpJeuySiiI\"," +
+            "        \"contents\": [" +
+            "          {" +
+            "            \"type\": \"raw\"," +
+            "            \"data\": {" +
+            "              \"height\": 1," +
+            "              \"width\": 1," +
+            "              \"ctTitle\": \"German Sausages\"," +
+            "              \"ctJoke\": \"I hate jokes about German sausages.  They're the wurst!\"" +
+            "            }," +
+            "            \"body\": \"{\\\"joke\\\": \\\"I hate jokes about German sausages.  They're the wurst!\\\",\\\"title\\\": \\\"German Sausages\\\",\\\"thumbnail\\\": \\\"\\\"}\"," +
+            "            \"customTemplate\": \"{\\\"joke\\\": \\\"{{ctJoke}}\\\",\\\"title\\\": \\\"{{ctTitle}}\\\",\\\"thumbnail\\\": \\\"{{ctThumbnailUrl}}\\\"}\"" +
+            "          }" +
+            "        ]," +
+            "        \"height\": 1," +
+            "        \"width\": 1," +
+            "        \"events\": []" +
+            "      }," +
+            "      {" +
+            "        \"adId\": 20857908," +
+            "        \"creativeId\": 18209782," +
+            "        \"flightId\": 12637352," +
+            "        \"campaignId\": 1772372," +
+            "        \"priorityId\": 208307," +
+            "        \"clickUrl\": \"https://e-9792.adzerk.net/r?e=eyJ2IjoiMS42IiwiYXYiOjkwNDA1MCwiYXQiOjE2MywiYnQiOjAsImNtIjoxNzcyMzcyLCJjaCI6NTE1MDksImNrIjp7fSwiY3IiOjE4MjA5NzgyLCJkaSI6IjMwZTZhYjRmY2U4NzRkNzJiNWJjMjdhNjZhMDRhYWM2IiwiZGoiOjEsImlpIjoiN2EwMDQwODUzZDdjNDg0ZDkxMzk4ZGFlM2E0ZGI4ZDgiLCJkbSI6MywiZmMiOjIwODU3OTA4LCJmbCI6MTI2MzczNTIsImlwIjoiMTM2LjU2LjI5LjY0IiwibnciOjk3OTIsInBjIjowLCJlYyI6MCwiZXAiOm51bGwsInByIjoyMDgzMDcsInJ0IjowLCJycyI6NTAwLCJzYSI6IjgiLCJzYiI6ImktMDk4YzBmNmY4MDg5ZjY0OTUiLCJzcCI6Mjc1NzIsInN0IjoxMTMzODk4LCJ1ayI6InVlMS1hNThkOTY3MTNmNmE0MWVkYjQyNjk1ZDI0MTc4ZTIyNCIsInRzIjoxNjAzNTc5NjI4ODM0LCJwbiI6ImRpdjEiLCJnYyI6dHJ1ZSwiZ0MiOnRydWUsImdzIjoibm9uZSIsInR6IjoiVVRDIiwidXIiOiJodHRwczovL3d3dy5hZHplcmsuY29tIn0&s=rsiZ3L8583Y-uBTQAvbZZMe0ABY\"," +
+            "        \"impressionUrl\": \"https://e-9792.adzerk.net/i.gif?e=eyJ2IjoiMS42IiwiYXYiOjkwNDA1MCwiYXQiOjE2MywiYnQiOjAsImNtIjoxNzcyMzcyLCJjaCI6NTE1MDksImNrIjp7fSwiY3IiOjE4MjA5NzgyLCJkaSI6IjMwZTZhYjRmY2U4NzRkNzJiNWJjMjdhNjZhMDRhYWM2IiwiZGoiOjEsImlpIjoiN2EwMDQwODUzZDdjNDg0ZDkxMzk4ZGFlM2E0ZGI4ZDgiLCJkbSI6MywiZmMiOjIwODU3OTA4LCJmbCI6MTI2MzczNTIsImlwIjoiMTM2LjU2LjI5LjY0IiwibnciOjk3OTIsInBjIjowLCJlYyI6MCwiZXAiOm51bGwsInByIjoyMDgzMDcsInJ0IjowLCJycyI6NTAwLCJzYSI6IjgiLCJzYiI6ImktMDk4YzBmNmY4MDg5ZjY0OTUiLCJzcCI6Mjc1NzIsInN0IjoxMTMzODk4LCJ1ayI6InVlMS1hNThkOTY3MTNmNmE0MWVkYjQyNjk1ZDI0MTc4ZTIyNCIsInRzIjoxNjAzNTc5NjI4ODM1LCJwbiI6ImRpdjEiLCJnYyI6dHJ1ZSwiZ0MiOnRydWUsImdzIjoibm9uZSIsInR6IjoiVVRDIiwiYmEiOjEsImZxIjowfQ&s=LSewbXP5-7Xu1IkoqS5Dj0rxuqY\"," +
+            "        \"contents\": [" +
+            "          {" +
+            "            \"type\": \"raw\"," +
+            "            \"data\": {" +
+            "              \"height\": 1," +
+            "              \"width\": 1," +
+            "              \"ctTitle\": \"Calendar Factory\"," +
+            "              \"ctJoke\": \"I had a job in a calendar factory, but I got sacked for taking a couple of days off.\"" +
+            "            }," +
+            "            \"body\": \"{\\\"joke\\\": \\\"I had a job in a calendar factory, but I got sacked for taking a couple of days off.\\\",\\\"title\\\": \\\"Calendar Factory\\\",\\\"thumbnail\\\": \\\"\\\"}\"," +
+            "            \"customTemplate\": \"{\\\"joke\\\": \\\"{{ctJoke}}\\\",\\\"title\\\": \\\"{{ctTitle}}\\\",\\\"thumbnail\\\": \\\"{{ctThumbnailUrl}}\\\"}\"" +
+            "          }" +
+            "        ]," +
+            "        \"height\": 1," +
+            "        \"width\": 1," +
+            "        \"events\": []" +
+            "      }," +
+            "      {" +
+            "        \"adId\": 20857909," +
+            "        \"creativeId\": 18209783," +
+            "        \"flightId\": 12637353," +
+            "        \"campaignId\": 1772372," +
+            "        \"priorityId\": 208307," +
+            "        \"clickUrl\": \"https://e-9792.adzerk.net/r?e=eyJ2IjoiMS42IiwiYXYiOjkwNDA1MCwiYXQiOjE2MywiYnQiOjAsImNtIjoxNzcyMzcyLCJjaCI6NTE1MDksImNrIjp7fSwiY3IiOjE4MjA5NzgzLCJkaSI6IjMwZTZhYjRmY2U4NzRkNzJiNWJjMjdhNjZhMDRhYWM2IiwiZGoiOjIsImlpIjoiY2ViOWEwZDEzZDdjNDdlYWE4MzNkZjkxNDMxMDA1NGUiLCJkbSI6MywiZmMiOjIwODU3OTA5LCJmbCI6MTI2MzczNTMsImlwIjoiMTM2LjU2LjI5LjY0IiwibnciOjk3OTIsInBjIjowLCJlYyI6MCwiZXAiOm51bGwsInByIjoyMDgzMDcsInJ0IjowLCJycyI6NTAwLCJzYSI6IjgiLCJzYiI6ImktMDk4YzBmNmY4MDg5ZjY0OTUiLCJzcCI6Mjc1NzIsInN0IjoxMTMzODk4LCJ1ayI6InVlMS1hNThkOTY3MTNmNmE0MWVkYjQyNjk1ZDI0MTc4ZTIyNCIsInRzIjoxNjAzNTc5NjI4ODM1LCJwbiI6ImRpdjEiLCJnYyI6dHJ1ZSwiZ0MiOnRydWUsImdzIjoibm9uZSIsInR6IjoiVVRDIiwidXIiOiJodHRwczovL3d3dy5hZHplcmsuY29tIn0&s=dG-uPwpEoJysf9oEAiBpVWip5R4\"," +
+            "        \"impressionUrl\": \"https://e-9792.adzerk.net/i.gif?e=eyJ2IjoiMS42IiwiYXYiOjkwNDA1MCwiYXQiOjE2MywiYnQiOjAsImNtIjoxNzcyMzcyLCJjaCI6NTE1MDksImNrIjp7fSwiY3IiOjE4MjA5NzgzLCJkaSI6IjMwZTZhYjRmY2U4NzRkNzJiNWJjMjdhNjZhMDRhYWM2IiwiZGoiOjIsImlpIjoiY2ViOWEwZDEzZDdjNDdlYWE4MzNkZjkxNDMxMDA1NGUiLCJkbSI6MywiZmMiOjIwODU3OTA5LCJmbCI6MTI2MzczNTMsImlwIjoiMTM2LjU2LjI5LjY0IiwibnciOjk3OTIsInBjIjowLCJlYyI6MCwiZXAiOm51bGwsInByIjoyMDgzMDcsInJ0IjowLCJycyI6NTAwLCJzYSI6IjgiLCJzYiI6ImktMDk4YzBmNmY4MDg5ZjY0OTUiLCJzcCI6Mjc1NzIsInN0IjoxMTMzODk4LCJ1ayI6InVlMS1hNThkOTY3MTNmNmE0MWVkYjQyNjk1ZDI0MTc4ZTIyNCIsInRzIjoxNjAzNTc5NjI4ODM1LCJwbiI6ImRpdjEiLCJnYyI6dHJ1ZSwiZ0MiOnRydWUsImdzIjoibm9uZSIsInR6IjoiVVRDIiwiYmEiOjEsImZxIjowfQ&s=9Cc2PNVr73d8p57vb_XjKmLpVfA\"," +
+            "        \"contents\": [" +
+            "          {" +
+            "            \"type\": \"raw\"," +
+            "            \"data\": {" +
+            "              \"height\": 1," +
+            "              \"width\": 1," +
+            "              \"ctTitle\": \"Terrified of Lifts\"," +
+            "              \"ctJoke\": \"I am terrified of lifts.  I'm going to start taking steps to avoid them.\"" +
+            "            }," +
+            "            \"body\": \"{\\\"joke\\\": \\\"I am terrified of lifts.  I'm going to start taking steps to avoid them.\\\",\\\"title\\\": \\\"Terrified of Lifts\\\",\\\"thumbnail\\\": \\\"\\\"}\"," +
+            "            \"customTemplate\": \"{\\\"joke\\\": \\\"{{ctJoke}}\\\",\\\"title\\\": \\\"{{ctTitle}}\\\",\\\"thumbnail\\\": \\\"{{ctThumbnailUrl}}\\\"}\"" +
+            "          }" +
+            "        ]," +
+            "        \"height\": 1," +
+            "        \"width\": 1," +
+            "        \"events\": []" +
+            "      }" +
+            "    ]" +
+            "  }" +
+            "}";
 }

--- a/sdk/src/test/java/com/adzerk/android/sdk/rest/PlacementTest.java
+++ b/sdk/src/test/java/com/adzerk/android/sdk/rest/PlacementTest.java
@@ -84,7 +84,8 @@ public class PlacementTest {
                 .setFlightId(flightId)
                 .setAdId(adId)
                 .setClickUrl(clickUrl)
-                .setEventIds(eventIds);
+                .setEventIds(eventIds)
+                .setCount(4);
 
             // verify
             assertThat(div1.getZoneIds()).containsAll(zoneIds);
@@ -93,6 +94,7 @@ public class PlacementTest {
             assertThat(div1.getAdId()).isEqualTo(adId);
             assertThat(div1.getClickUrl()).isEqualTo(clickUrl);
             assertThat(div1.getEventIds()).containsAll(eventIds);
+            assertThat(div1.getCount()).isEqualTo(4);
 
         } catch(IllegalArgumentException e) {
             fail("Should not throw exception: " + e.getMessage());
@@ -160,6 +162,24 @@ public class PlacementTest {
         assertThat(jsonElement).isEqualToComparingFieldByField(expectedJsonElement);
     }
 
+    @Test
+    public void itShouldSerializePlacementWithCount() {
+        // create placements will count attribute
+        Placement div1 = new Placement("div1", 123L, 456L, 4, 5)
+                .setCount(4);
+
+        // serialize Placement to json
+        Gson gson = new GsonBuilder().create();
+        String json = gson.toJson(div1);
+        JsonElement jsonElement = gson.toJsonTree(div1);
+
+        // expected json
+        JsonElement expectedJsonElement = gson.fromJson(jsonPlacementWithCount, JsonElement.class);
+
+        // verify results
+        assertThat(json).isNotEmpty();
+        assertThat(jsonElement).isEqualToComparingFieldByField(expectedJsonElement);
+    }
 
     public static final String jsonPlacement1 = "{" +
           "  \"divName\": \"div1\"," +
@@ -179,4 +199,11 @@ public class PlacementTest {
           "  }" +
           "}";
 
+    public static final String jsonPlacementWithCount = "{" +
+            "  \"divName\": \"div1\"," +
+            "  \"networkId\": 123," +
+            "  \"siteId\": 456," +
+            "  \"adTypes\": [4, 5]," +
+            "  \"count\": 4" +
+            "}";
 }


### PR DESCRIPTION
Add support for multi-winner Placements

This a breaking change. Response will always return a List, even for singe winner cases
- `DecisionResponse: getDecision(name)` has been replaced by `getDecisions(name)` which returns `List<Decision>`
- `DecisionResponse: getDecisions()` now returns  map from Placement name to decisions list:` Map<String, List<Decision>>`

`DecisionsDeserializer` handles custom deserialization for both single-winner and multi-winner responses from the API and always creates a List.

Example request for multi-winner placement:

```
   Request request = new Request.Builder()
      .addPlacement(new Placement("div1", 1133898L, 163).setCount(3))
      .build();
```

fixes: #74 