### PR TITLE
remove support for outdated time param on requests

### DIFF
--- a/sdk/src/main/java/com/adzerk/android/sdk/rest/Request.java
+++ b/sdk/src/main/java/com/adzerk/android/sdk/rest/Request.java
@@ -51,9 +51,6 @@ public class Request {
     // URL to use as the current page URL when selecting an ad
     String url;
 
-    // UNIX epoch timestamp to use when selecting an ad
-    Long time;
-
     // IP address to use when selecting the ad; if specified, overrides the IP the request is made from
     String ip;
 
@@ -93,7 +90,6 @@ public class Request {
         private Set<String> keywords;
         private String referrer;
         private String url;
-        private Long time;
         private String ip;
         private Set<Integer> blockedCreatives;
         private Map<Integer, List<Long>> flightViewTimes;
@@ -223,17 +219,6 @@ public class Request {
         }
 
         /**
-         * Timestamp to use when selecting an ad
-         *
-         * @param time  UNIX epoch timestamp
-         * @return request builder
-         */
-        public Builder setTime(long time) {
-            this.time = time;
-            return this;
-        }
-
-        /**
          * IP address to use when selecting the ad. If specified, overrides the IP the request is made from
          *
          * @param ip    ip address
@@ -330,9 +315,6 @@ public class Request {
         setKeywords(builder.keywords);
         setReferrer(builder.referrer);
         setUrl(builder.url);
-        if (builder.time != null) {
-            setTime(builder.time);
-        }
         setIp(builder.ip);
         setBlockedCreatives(builder.blockedCreatives);
         setAllFlightViewTimes(builder.flightViewTimes);
@@ -402,19 +384,6 @@ public class Request {
 
     public void setUrl(String url) {
         this.url = url;
-    }
-
-    /**
-     * Returns the UNIX epoch timestamp to use when selecting an ad
-     *
-     * @return  epoch timestamp
-     */
-    public long getTime() {
-        return time;
-    }
-
-    public void setTime(long time) {
-        this.time = time;
     }
 
     /**

--- a/sdk/src/test/java/com/adzerk/android/sdk/rest/RequestTest.java
+++ b/sdk/src/test/java/com/adzerk/android/sdk/rest/RequestTest.java
@@ -194,22 +194,6 @@ public class RequestTest {
     }
 
     @Test
-    public void itShouldBuildTime() {
-        try {
-            long time = 1437425417;
-
-            Request request = new Builder(placements)
-                  .setTime(time)
-                  .build();
-
-            assertThat(request.getTime()).isEqualTo(time);
-
-        } catch (IllegalArgumentException e) {
-            fail("Should not throw exception: " + e.getMessage());
-        }
-    }
-
-    @Test
     public void itShouldBuildIp() {
         try {
             String ip = "192.168.1.1";
@@ -247,7 +231,6 @@ public class RequestTest {
         try {
             int blocked1 = 1;
             int blocked2 = 2;
-            int blocked3 = 3;
 
             Request request = new Builder(placements)
                   .addBlockedCreatives(blocked1, blocked2)


### PR DESCRIPTION
Removes `time` from the ad Request

fixes: 77