### PR TITLE
support enableBotFiltering and default to false

### DIFF
--- a/sdk/src/main/java/com/adzerk/android/sdk/rest/Request.java
+++ b/sdk/src/main/java/com/adzerk/android/sdk/rest/Request.java
@@ -66,6 +66,9 @@ public class Request {
     // sets data consent preferences
     Consent consent;
 
+    // enables automatic filtering-out of impressions from bots and spiders; defaults to false
+    boolean enableBotFiltering = false;
+
     /**
      * Builder to configure a Request for ads.
      * <p>
@@ -98,6 +101,7 @@ public class Request {
         private Set<Integer> blockedCreatives;
         private Map<Integer, List<Long>> flightViewTimes;
         private Consent consent;
+        private boolean enableBotFiltering = false;
 
 
         /**
@@ -300,10 +304,22 @@ public class Request {
          *
          * For example, GDPR consent for tracking in the European Union (This defaults to false).
          *
-         * @return
+         * @return request builder
          */
         public Builder setConsent(Consent consent) {
             this.consent = consent;
+            return this;
+        }
+
+        /**
+         * Enable or disable bot filtering feature. Bot filtering automatically filters out
+         * impressions from bots and spiders. Disabled by default for mobile clients.
+         *
+         * @param enableBotFiltering enable or disable bot filtering feature
+         * @return request builder
+         */
+        public Builder setBotFilteringEnabled(boolean enableBotFiltering) {
+            this.enableBotFiltering = enableBotFiltering;
             return this;
         }
 
@@ -337,6 +353,7 @@ public class Request {
         setBlockedCreatives(builder.blockedCreatives);
         setAllFlightViewTimes(builder.flightViewTimes);
         setConsent(builder.consent);
+        setBotFilteringEnabled(builder.enableBotFiltering);
     }
 
     /**
@@ -484,5 +501,19 @@ public class Request {
 
     private void setConsent(Consent consent) {
         this.consent = consent;
+    }
+
+    /**
+     * Returns whether bot filtering feature is enabled. Bot filtering automatically filters out
+     * impressions from bots and spiders. Disabled by default for mobile clients.
+     *
+     * @return true if bot filtering has been enabled; default is false
+     */
+    public boolean isBotFilteringEnabled() {
+        return this.enableBotFiltering;
+    }
+
+    private void setBotFilteringEnabled(boolean enableBotFiltering) {
+        this.enableBotFiltering = enableBotFiltering;
     }
 }

--- a/sdk/src/test/java/com/adzerk/android/sdk/rest/RequestTest.java
+++ b/sdk/src/test/java/com/adzerk/android/sdk/rest/RequestTest.java
@@ -304,4 +304,26 @@ public class RequestTest {
         }
     }
 
+    @Test
+    public void itShouldDisableBotFiltering() {
+
+        try {
+            Request request = new Builder(placements).build();
+            assertThat(request.isBotFilteringEnabled()).isEqualTo(false);
+        } catch (IllegalArgumentException e) {
+            fail("Should not throw exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void itShouldEnableBotFiltering() {
+
+        try {
+            Request request = new Builder(placements).setBotFilteringEnabled(true).build();
+            assertThat(request.isBotFilteringEnabled()).isEqualTo(true);
+        } catch (IllegalArgumentException e) {
+            fail("Should not throw exception: " + e.getMessage());
+        }
+    }
+
 }


### PR DESCRIPTION
Adds support to specify `enableBotFiltering` on ad Request. Defaults to false.

fixes: #76 